### PR TITLE
Comment out  #![feature(const_fn)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn)]
+// #![feature(const_fn)]
 
 extern crate vst;
 #[macro_use] extern crate log;


### PR DESCRIPTION
Hello there! Thanks for the code!

The only thing preventing easyvst from compiling in stable Rust is this directive, so I propose its removal.

On the other hand, the conrodgain example does not work for me on Windows 10 -- no GUI appears even with a font.ttf file in the same directory as the DDL.  I wonder if this could be related to const_fn (I guess not), as I am just a noob in the language.

If you think I should switch to unstable Rust, I would appreciate to know the reasons (maybe even add these reasons to the docs).