### PR TITLE
derive(Clone, Debug, Default)

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -3,6 +3,7 @@ use asprim::AsPrim;
 
 use util::*;
 
+#[derive(Clone, Debug, Default)]
 pub struct ParamDef {
 	pub name: &'static str,
 	pub min: f32,
@@ -21,6 +22,7 @@ impl ParamDef {
 	}
 }
 
+#[derive(Clone, Debug, Default)]
 pub struct Param {
 	pub def: ParamDef,
 	pub val: f32,


### PR DESCRIPTION
I am using Param and ParamDef without using the rest of the library (so far).

When I tried to store Params in an array, Rust complained that it couldn't, for lack of one of these basic traits.  If one of them is inappropriate, please enlighten this Rust beginner.